### PR TITLE
Optimizations: registers, DRW

### DIFF
--- a/Chip8Sharp/JIT/Implementation.cs
+++ b/Chip8Sharp/JIT/Implementation.cs
@@ -16,7 +16,8 @@ namespace Chip8Sharp.JIT
 		/// </summary>
 		internal static void EmitGetRegister(this ILGenerator gen, int N, JITContext ctx)
 		{
-			gen.Emit(OpCodes.Ldloc, (short)N);
+			gen.Emit(OpCodes.Ldarg_1);
+			gen.Emit(OpCodes.Ldflda, Registers.Fields[N]);
 		}
 
 		internal static void EmitLoadImmediate(this ILGenerator gen, Disassembler.DecompEntry inst) =>
@@ -81,6 +82,7 @@ namespace Chip8Sharp.JIT
 		public static void CALL(JITContext ctx, Disassembler.DecompEntry inst, ILGenerator gen)
 		{
 			gen.Emit(OpCodes.Ldarg_0);
+			gen.Emit(OpCodes.Ldarg_1);
 			gen.Emit(OpCodes.Call, ctx.Functions[inst.Value.Immediate16].Method);
 		}
 
@@ -251,14 +253,14 @@ namespace Chip8Sharp.JIT
 			gen.Emit(OpCodes.Ldind_U1); //Load value
 
 			gen.Emit(OpCodes.Dup); //duplicate value for VF comparison
-			gen.Emit(OpCodes.Stloc_S, (byte)0x10); //Store for VF comparison
+			gen.Emit(OpCodes.Stloc_0); //Store for VF comparison
 
 			gen.Emit(OpCodes.Ldc_I4_1);
 			gen.Emit(OpCodes.Shr_Un); //Shift and store
 			gen.Emit(OpCodes.Stind_I1);
 
 			gen.EmitGetRegister(0xF, ctx);
-			gen.Emit(OpCodes.Ldloc, (short)0x10);
+			gen.Emit(OpCodes.Ldloc_0);
 			gen.Emit(OpCodes.Ldc_I4_1);
 			gen.Emit(OpCodes.And);
 			gen.Emit(OpCodes.Stind_I1);
@@ -275,13 +277,13 @@ namespace Chip8Sharp.JIT
 			gen.Emit(OpCodes.Ldind_U1); //Load value
 
 			gen.Emit(OpCodes.Dup); //duplicate value for VF comparison
-			gen.Emit(OpCodes.Stloc_S, (byte)0x10); //Store for VF comparison
+			gen.Emit(OpCodes.Stloc_0); //Store for VF comparison
 
 			gen.Emit(OpCodes.Ldc_I4_1);
 			gen.Emit(OpCodes.Shl); //Shift and store
 			gen.Emit(OpCodes.Stind_I1);
 
-			gen.Emit(OpCodes.Ldloc, (short)0x10);
+			gen.Emit(OpCodes.Ldloc_0);
 			gen.Emit(OpCodes.Ldc_I4, 0x80);
 			gen.Emit(OpCodes.And);
 			gen.Emit(OpCodes.Ldc_I4_0);

--- a/Chip8SharpJITTests/JITTests.cs
+++ b/Chip8SharpJITTests/JITTests.cs
@@ -13,7 +13,7 @@ namespace Chip8SharpJITTests
 				state = new Chip8State();
 
 			ROM.CopyTo(state.ProgramRegion.Span);
-			new Chip8Sharp.JIT.JIT().JITROM(ROM)(state);
+			new Chip8Sharp.JIT.JIT().JITROM(ROM)(state, ref state.Registers);
 			return state;
 		}
 	}
@@ -375,7 +375,7 @@ namespace Chip8SharpJITTests
 		{
 			byte[] ROM = new byte[] { 0xC0, 0x7F };
 			var state = Helper.JITAndExecuteROM(ROM);
-			Assert.IsTrue((state.V0 & 0x80) == 0);
+			Assert.IsTrue((state.Registers.V0 & 0x80) == 0);
 			state.AssertRegsZeroExcept(0);
 		}
 
@@ -585,7 +585,7 @@ namespace Chip8SharpJITTests
 
 		public static Chip8State AssertRegsZeroExcept(this Chip8State state, params int[] values)
 		{
-			var regs = state.Registers.Span;
+			var regs = state.Registers.AsSpan();
 			for (int i = 0; i < regs.Length; i++)
 				if (!values.Contains(i))	
 					Assert.AreEqual(0, regs[i]);

--- a/SharpConsole/Program.cs
+++ b/SharpConsole/Program.cs
@@ -141,7 +141,7 @@ namespace SharpConsole
 				}
 
 				for (int i = 0; i < 16; i++)
-					console.Write($"V{i.ToString("X")}: {inr.State.Register((byte)i).ToString("X2")}   | ", inr.State.Registers.Span[i] != OldRegisters[i] ? ConsoleColor.Red : ConsoleColor.White);
+					console.Write($"V{i.ToString("X")}: {inr.State.Register((byte)i).ToString("X2")}   | ", inr.State.Registers.AsSpan()[i] != OldRegisters[i] ? ConsoleColor.Red : ConsoleColor.White);
 				console.Write($"I: {inr.State.I.ToString("X4")}   |", inr.State.I != OldI ? ConsoleColor.Red : ConsoleColor.White);
 				console.Write($"PC: {inr.State.PC.ToString("X4")}   |");
 				console.Write($"SP: {inr.State.SP.ToString("X4")}   |");
@@ -150,7 +150,7 @@ namespace SharpConsole
 
 				console.WriteLine("");
 				
-				OldRegisters = inr.State.Registers.ToArray();
+				OldRegisters = inr.State.Registers.AsSpan().ToArray();
 				OldI = inr.State.I;
 
 				console.Write("Space: ", ConsoleColor.Cyan);


### PR DESCRIPTION
I have slightly optimized registers access with JIT and DRW call

Before
```c#
00:00:01.0733303 DBG interperter
00:00:00.9509722 Interperter
00:00:00.0250618 JIT
```
After
```c#
00:00:01.0852349 DBG interperter
00:00:00.9618549 Interperter
00:00:00.0192523 JIT
```